### PR TITLE
Add path-ops module for path matching

### DIFF
--- a/worker/src/api-config.json
+++ b/worker/src/api-config.json
@@ -15,6 +15,14 @@
             }
         },
         {
+            "method": "GET",
+            "path": "/api/v1/ngrok/{parameter}",
+            "integration": {
+                "type": "http_proxy",
+                "server": "ngrok"
+            }
+        },
+        {
             "method": "POST",
             "path": "/api/v1/ngrok",
             "integration": {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,5 +1,4 @@
 import apiConfig from './api-config.json';
-import './path-ops';
 import { pathsMatch } from './path-ops';
 
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,19 +1,17 @@
 import apiConfig from './api-config.json';
+import './path-ops';
+import { pathsMatch } from './path-ops';
 
-// Export a default object containing event handlers
+
 export default {
-	// The fetch handler is invoked when this worker receives a HTTP(S) request
-	// and should return a Response (optionally wrapped in a Promise)
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-		// You'll find it helpful to parse the request.url string into a URL object. Learn more at https://developer.mozilla.org/en-US/docs/Web/API/URL
 		const url = new URL(request.url);
 
-		var matchedPath = apiConfig.paths.find((item) => item.path === url.pathname && item.method === request.method);
+		var matchedPath = apiConfig.paths.find((item) => pathsMatch(item.path, url.pathname) && item.method === request.method);
 		console.log(matchedPath);
 		if (matchedPath) {
-			console.log(matchedPath);
 			if (matchedPath.integration) {
-				console.log('type:'+matchedPath.integration.type);
+				console.log('type:' + matchedPath.integration.type);
 				if (matchedPath.integration.type === 'http_proxy') {
 					const server = apiConfig.servers.find((server) => server.alias === matchedPath?.integration?.server);
 					console.log(server);

--- a/worker/src/path-ops.ts
+++ b/worker/src/path-ops.ts
@@ -1,0 +1,25 @@
+function isPathParam(segment: string): boolean {
+	return segment.startsWith('{') && segment.endsWith('}');
+}
+
+// Function to match the paths
+function pathsMatch(apiPath: string, urlPath: string): boolean {
+	const apiSegments = apiPath.split('/');
+	const urlSegments = urlPath.split('/');
+
+	// Ensure the paths have the same number of segments
+	if (apiSegments.length !== urlSegments.length) {
+		return false;
+	}
+
+	// Compare each segment
+	for (let i = 0; i < apiSegments.length; i++) {
+		if (!isPathParam(apiSegments[i]) && apiSegments[i] !== urlSegments[i]) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+export { pathsMatch };


### PR DESCRIPTION
This pull request adds a new module called path-ops that contains a function to match paths. The function is used in the fetch handler to match API paths with URL paths. Additionally, an unused import in index.ts has been removed.
Closes #11